### PR TITLE
Update RepositoryTrait.php

### DIFF
--- a/src/RepositoryTrait.php
+++ b/src/RepositoryTrait.php
@@ -53,8 +53,6 @@ trait RepositoryTrait
      */
     public function getTemplateName(...$objects)
     {
-        $objects[] = $this;
-
         return collect($objects)->reduce(
             fn($name, $object) => $name ??
                 $this->getTemplateNameFromObject($object),


### PR DESCRIPTION
`Error: Cannot use object of type App\Repositories\...Repository as array`

We will got an error exception if we didn't set $templateName variable in transformer class file
In my mind, we don't need to set $templateName in repository, so why we need put repository class into finding-loop?

